### PR TITLE
Auto-confirm init questions and add eviroment variable support

### DIFF
--- a/src/FlanCommand.ts
+++ b/src/FlanCommand.ts
@@ -115,12 +115,14 @@ export default abstract class FlanCommand extends Command {
     }
 
     if (process.env.FLAN_REPO_DIR || configJSON.repoDir) {
+      // the "" is needed to suppress a TypeScript error, it will not be used
       this.localConfig.repoDir = path.resolve(
         process.env.FLAN_REPO_DIR || configJSON.repoDir || ""
       );
     }
 
     if (process.env.FLAN_SAVE_DIR || configJSON.saveDir) {
+      // the "" is needed to suppress a TypeScript error, it will not be used
       this.localConfig.saveDir = path.resolve(
         process.env.FLAN_SAVE_DIR || configJSON.saveDir || ""
       );

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,7 +11,7 @@ export default class Init extends FlanCommand {
 
   static flags = {
     ...FlanCommand.flags,
-    confirm: flags.boolean({
+    yes: flags.boolean({
       char: "y",
       description: "Auto confirm directory creating questions",
     }),
@@ -100,7 +100,7 @@ Git repository initialized at /home/flan/some-folder/.flan/repo
 
     if (!(await fs.pathExists(baseDir))) {
       if (
-        flags.confirm ||
+        flags.yes ||
         (await cli.confirm(
           `A base directory will be created at ${baseDir}, continue? [y/n]`
         ))
@@ -119,7 +119,7 @@ Git repository initialized at /home/flan/some-folder/.flan/repo
 
     if (!(await fs.pathExists(saveDir))) {
       if (
-        flags.confirm ||
+        flags.yes ||
         (await cli.confirm(
           `A save directory will be created at ${saveDir}, continue? [y/n]`
         ))
@@ -138,7 +138,7 @@ Git repository initialized at /home/flan/some-folder/.flan/repo
 
     if (!(await fs.pathExists(repoDir))) {
       if (
-        flags.confirm ||
+        flags.yes ||
         (await cli.confirm(
           `A git repository will be initialized at ${repoDir}, continue? [y/n]`
         ))

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,3 +1,4 @@
+import { flags } from "@oclif/command";
 import fs from "fs-extra";
 import path from "path";
 import execa from "execa";
@@ -10,6 +11,10 @@ export default class Init extends FlanCommand {
 
   static flags = {
     ...FlanCommand.flags,
+    confirm: flags.boolean({
+      char: "y",
+      description: "Auto confirm directory creating questions",
+    }),
   };
 
   static examples = [
@@ -21,6 +26,12 @@ A config file will be created, continue? [y/n]
 `,
     `$ flan init -c /some-folder/flan.config.json
 Config file found at home/flan/some-folder/flan.config.json
+`,
+    `$ flan init -y -c /some-folder/flan.config.json
+Config file found at /home/flan/some-folder/flan.config.json
+The base directory has been created successfully at /home/flan/some-folder/.flan
+The save directory has been created successfully at /home/flan/some-folder/.flan/local
+Git repository initialized at /home/flan/some-folder/.flan/repo
 `,
   ];
 
@@ -89,9 +100,10 @@ Config file found at home/flan/some-folder/flan.config.json
 
     if (!(await fs.pathExists(baseDir))) {
       if (
-        await cli.confirm(
+        flags.confirm ||
+        (await cli.confirm(
           `A base directory will be created at ${baseDir}, continue? [y/n]`
-        )
+        ))
       ) {
         await fs.ensureDir(baseDir);
 
@@ -107,9 +119,10 @@ Config file found at home/flan/some-folder/flan.config.json
 
     if (!(await fs.pathExists(saveDir))) {
       if (
-        await cli.confirm(
+        flags.confirm ||
+        (await cli.confirm(
           `A save directory will be created at ${saveDir}, continue? [y/n]`
-        )
+        ))
       ) {
         await fs.ensureDir(saveDir);
 
@@ -125,9 +138,10 @@ Config file found at home/flan/some-folder/flan.config.json
 
     if (!(await fs.pathExists(repoDir))) {
       if (
-        await cli.confirm(
+        flags.confirm ||
+        (await cli.confirm(
           `A git repository will be initialized at ${repoDir}, continue? [y/n]`
-        )
+        ))
       ) {
         await fs.ensureDir(repoDir);
         await execa("git", ["init"], {


### PR DESCRIPTION
Changes in this MR:

- Add "-y" flag to the init command. When it's passed it with auto-confirm all the questions about adding directories. This makes the init command more script friendly.
- Add environment variable support for configuration parameters. When there is an environment variables use those to override config file configuration. Also remove error when there is no config file, in this case we will use the defaults along with any environment variable values we find.