### PR TITLE
Clean up pg command args and add flags for load

### DIFF
--- a/src/commands/load.ts
+++ b/src/commands/load.ts
@@ -10,7 +10,7 @@ import { checkDumpNameForTag } from "../utils";
 export default class Load extends FlanCommand {
   static description = "load database from dump";
 
-  static examples = ["$ flan load myDB"];
+  static examples = ["$ flan load myDB", "$ flan load --dropDB --quiet myDB"];
 
   static flags = {
     ...FlanCommand.flags,

--- a/src/commands/load.ts
+++ b/src/commands/load.ts
@@ -10,11 +10,11 @@ import { checkDumpNameForTag } from "../utils";
 export default class Load extends FlanCommand {
   static description = "load database from dump";
 
-  static examples = ["$ flan load myDB", "$ flan load --dropDB --quiet myDB"];
+  static examples = ["$ flan load myDB", "$ flan load --drop-db --quiet myDB"];
 
   static flags = {
     ...FlanCommand.flags,
-    dropDB: flags.boolean({
+    "drop-db": flags.boolean({
       default: false,
       description: "Drops and re-creates the DB before restoring it's data",
     }),
@@ -58,7 +58,7 @@ export default class Load extends FlanCommand {
       });
     }
 
-    if (flags.dropDB && this.localConfig.database.user) {
+    if (flags["drop-db"] && this.localConfig.database.user) {
       this.log(`recreating ${this.localConfig.database.db}`);
       const dropDbArgs = [
         "postgres",

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -95,8 +95,6 @@ export default class Save extends FlanCommand {
       `--jobs=${Math.floor(os.cpus().length / 2)}`,
       "--compress=9",
       "--format=directory",
-      "--clean",
-      "--no-owner",
       ...this.getPgConnectionArgs(),
       `--file=${dir}`,
     ];


### PR DESCRIPTION
This pull request aims to accomplish the following:

1. Clean up the arguments we pass into `pg_dump` and `pg_restore` to reduce error output.
2. Add some control flags to the `load` command:
  a. dropDB: drops and recreates the database before restoring the data to grantee the new DB is clean.
  b. quiet: control weather common errors from pg_restore should be suppressed or not.