### PR TITLE
Add support for PGPORT, Print out errors when flag.quiet=false for PG Restore + Override variables with PG env variables

### DIFF
--- a/src/FlanCommand.ts
+++ b/src/FlanCommand.ts
@@ -6,7 +6,7 @@ import * as fs from "fs-extra";
 
 export default abstract class FlanCommand extends Command {
   localConfig: {
-    database: { host: string; db: string; user?: string };
+    database: { host: string; db: string; user?: string; port?: number };
     baseDir: string;
     saveDir: string;
     repoDir: string;
@@ -36,6 +36,7 @@ export default abstract class FlanCommand extends Command {
         host: "",
         db: "",
         user: "",
+        port: 5432
       },
     };
   }
@@ -53,13 +54,14 @@ export default abstract class FlanCommand extends Command {
       `--dbname=${this.localConfig.database.db}`,
       "-U",
       this.localConfig.database.user as string,
+      `--port=${this.localConfig.database.port}`
     ];
   }
 
   async loadConfigFile(configPath: string) {
     // load config file if it exsits
     let configJSON: {
-      database?: { host?: string; db?: string; user?: string };
+      database?: { host?: string; db?: string; user?: string, port?:number };
       baseDir?: string;
       saveDir?: string;
       repoDir?: string;
@@ -109,6 +111,10 @@ export default abstract class FlanCommand extends Command {
           process.env.FLAN_DB_USER ||
           configJSON.database?.user ||
           this.localConfig.database.user,
+        port:
+          process.env.FLAN_DB_PORT ||
+          configJSON.database?.port ||
+          this.localConfig.database.port,
       },
     };
 

--- a/src/FlanCommand.ts
+++ b/src/FlanCommand.ts
@@ -6,7 +6,7 @@ import * as fs from "fs-extra";
 
 export default abstract class FlanCommand extends Command {
   localConfig: {
-    database: { host: string; db: string; user?: string; port?: number };
+    database: { host: string; db: string; user?: string; port?: string };
     baseDir: string;
     saveDir: string;
     repoDir: string;
@@ -36,7 +36,7 @@ export default abstract class FlanCommand extends Command {
         host: "",
         db: "",
         user: "",
-        port: 5432
+        port: "",
       },
     };
   }
@@ -54,14 +54,14 @@ export default abstract class FlanCommand extends Command {
       `--dbname=${this.localConfig.database.db}`,
       "-U",
       this.localConfig.database.user as string,
-      `--port=${this.localConfig.database.port}`
+      `--port=${this.localConfig.database.port}`,
     ];
   }
 
   async loadConfigFile(configPath: string) {
     // load config file if it exsits
     let configJSON: {
-      database?: { host?: string; db?: string; user?: string, port?:number };
+      database?: { host?: string; db?: string; user?: string; port?: string };
       baseDir?: string;
       saveDir?: string;
       repoDir?: string;
@@ -98,21 +98,18 @@ export default abstract class FlanCommand extends Command {
       database: {
         host:
           process.env.PGHOST ||
-          process.env.FLAN_DB_HOST ||
           configJSON.database?.host ||
           this.localConfig.database.host,
         db:
           process.env.PGDATABASE ||
-          process.env.FLAN_DB_NAME ||
           configJSON.database?.db ||
           this.localConfig.database.db,
         user:
           process.env.PGUSER ||
-          process.env.FLAN_DB_USER ||
           configJSON.database?.user ||
           this.localConfig.database.user,
         port:
-          process.env.FLAN_DB_PORT ||
+          process.env.PGPORT ||
           configJSON.database?.port ||
           this.localConfig.database.port,
       },

--- a/src/FlanCommand.ts
+++ b/src/FlanCommand.ts
@@ -33,10 +33,10 @@ export default abstract class FlanCommand extends Command {
       saveDir: ".flan/local",
       repoDir: ".flan/repo",
       database: {
-        host: "",
+        host: "localhost",
         db: "",
         user: "",
-        port: "",
+        port: "5432",
       },
     };
   }

--- a/src/FlanCommand.ts
+++ b/src/FlanCommand.ts
@@ -33,7 +33,7 @@ export default abstract class FlanCommand extends Command {
       saveDir: ".flan/local",
       repoDir: ".flan/repo",
       database: {
-        host: "localhost",
+        host: "",
         db: "",
         user: "",
       },
@@ -95,14 +95,17 @@ export default abstract class FlanCommand extends Command {
       ),
       database: {
         host:
+          process.env.PGHOST ||
           process.env.FLAN_DB_HOST ||
           configJSON.database?.host ||
           this.localConfig.database.host,
         db:
+          process.env.PGDATABASE ||
           process.env.FLAN_DB_NAME ||
           configJSON.database?.db ||
           this.localConfig.database.db,
         user:
+          process.env.PGUSER ||
           process.env.FLAN_DB_USER ||
           configJSON.database?.user ||
           this.localConfig.database.user,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -62,6 +62,7 @@ Git repository initialized at /home/flan/some-folder/.flan/repo
           "(Optional) Please enter your database port",
           {
             required: false,
+            default: "5432",
           }
         );
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -58,6 +58,13 @@ Git repository initialized at /home/flan/some-folder/.flan/repo
           }
         );
 
+        const port = await cli.prompt(
+          "(Optional) Please enter your database port",
+          {
+            required: false,
+          }
+        );
+
         const user = await cli.prompt(
           "(Optional) Please enter your database username",
           { required: false }
@@ -80,6 +87,7 @@ Git repository initialized at /home/flan/some-folder/.flan/repo
             baseDir: this.localConfig.baseDir,
             database: {
               host,
+              port,
               db,
               user,
             },

--- a/src/commands/load.ts
+++ b/src/commands/load.ts
@@ -87,7 +87,12 @@ export default class Load extends FlanCommand {
         path.resolve(loadPath, input),
       ]);
     } catch (error) {
-      if (!flags.quiet) {
+      if (
+        !flags.quiet &&
+        !/pg_restore: warning: errors ignored on restore: \d+\s*$/gim.test(
+          error.stderr
+        )
+      ) {
         this.error(error.stderr || error.message);
       }
     }

--- a/src/commands/load.ts
+++ b/src/commands/load.ts
@@ -87,12 +87,7 @@ export default class Load extends FlanCommand {
         path.resolve(loadPath, input),
       ]);
     } catch (error) {
-      if (
-        flags.quiet &&
-        !/pg_restore: warning: errors ignored on restore: \d+\s*$/gim.test(
-          error.stderr
-        )
-      ) {
+      if (!flags.quiet) {
         this.error(error.stderr || error.message);
       }
     }


### PR DESCRIPTION
There was a bug where we weren't printing out errors when PG_Restore failed. Causing it to error out silently. Additionally, we weren't allowing existing flan variables to be overridden by Postgres ones. 