### PR TITLE
Update tagRegex to support new tag format e.g. 2026.3.2+1

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ EXAMPLE
   $ flan available
 ```
 
-_See code: [src/commands/available.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.11/src/commands/available.ts)_
+_See code: [src/commands/available.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.12/src/commands/available.ts)_
 
 ## `flan delete DELETEFILE`
 
@@ -133,7 +133,7 @@ EXAMPLES
   $ flan delete myDB@1.0.0
 ```
 
-_See code: [src/commands/delete.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.11/src/commands/delete.ts)_
+_See code: [src/commands/delete.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.12/src/commands/delete.ts)_
 
 ## `flan fetch FILE`
 
@@ -153,7 +153,7 @@ EXAMPLE
   $ flan fetch filename
 ```
 
-_See code: [src/commands/fetch.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.11/src/commands/fetch.ts)_
+_See code: [src/commands/fetch.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.12/src/commands/fetch.ts)_
 
 ## `flan help [COMMAND]`
 
@@ -201,7 +201,7 @@ EXAMPLES
   Git repository initialized at /home/flan/some-folder/.flan/repo
 ```
 
-_See code: [src/commands/init.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.11/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.12/src/commands/init.ts)_
 
 ## `flan list`
 
@@ -218,7 +218,7 @@ EXAMPLE
   $ flan list
 ```
 
-_See code: [src/commands/list.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.11/src/commands/list.ts)_
+_See code: [src/commands/list.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.12/src/commands/list.ts)_
 
 ## `flan load INPUT`
 
@@ -241,7 +241,7 @@ EXAMPLES
   $ flan load --drop-db --quiet myDB
 ```
 
-_See code: [src/commands/load.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.11/src/commands/load.ts)_
+_See code: [src/commands/load.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.12/src/commands/load.ts)_
 
 ## `flan publish FILE`
 
@@ -261,7 +261,7 @@ EXAMPLE
   $ flan publish filename
 ```
 
-_See code: [src/commands/publish.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.11/src/commands/publish.ts)_
+_See code: [src/commands/publish.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.12/src/commands/publish.ts)_
 
 ## `flan save OUTPUT`
 
@@ -281,7 +281,7 @@ EXAMPLE
   $ flan save myDB
 ```
 
-_See code: [src/commands/save.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.11/src/commands/save.ts)_
+_See code: [src/commands/save.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.12/src/commands/save.ts)_
 
 ## `flan unpublish FILE`
 
@@ -301,7 +301,7 @@ EXAMPLE
   $ flan unpublish myDB@1.0.0
 ```
 
-_See code: [src/commands/unpublish.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.11/src/commands/unpublish.ts)_
+_See code: [src/commands/unpublish.ts](https://github.com/sdelements/flan/blob/v0.1.0-alpha.12/src/commands/unpublish.ts)_
 
 <!-- commandsstop -->
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sdelements/flan",
   "description": "A tasty tool that lets you save, load and share postgres snapshots with ease.",
-  "version": "0.1.0-alpha.11",
+  "version": "0.1.0-alpha.12",
   "author": "Houssam Haidar",
   "bin": {
     "flan": "./bin/run"

--- a/src/commands/available.ts
+++ b/src/commands/available.ts
@@ -96,7 +96,8 @@ export default class Available extends FlanCommand {
     const { stdout } = await execa("git", ["ls-remote", "--tags", repository], {
       cwd: this.localConfig.repoDir,
     });
-    const tagRegex = /(?<sha>[a-z0-9]+)\srefs\/tags\/(?<tag>[\w\.\-@]+)$/gim;
+    // Supports tag formats such as 2025.3.2 and 2026.3.2+1
+    const tagRegex = /(?<sha>[a-z0-9]+)\srefs\/tags\/(?<tag>[\w\.\+\-@]+)$/gim;
 
     let match;
     const tags = [];


### PR DESCRIPTION
We noticed new cypress_db with new tag format (`<year>.<month>.<sequence>+build`) are not available through `flan` command. In this PR, we update `tagRegex` format to support the new tag format as well as old format.

Refs: CI-1847